### PR TITLE
Fix: could not handle RTT > 100ms on Linux

### DIFF
--- a/deadman
+++ b/deadman
@@ -252,6 +252,8 @@ class PingLinux :
         pingcmd = sshcmd + pingcmdstr + " %s" % self.addr
         result = commands.getoutput (pingcmd)
         m = re.search (r'time=\d+\.\d+', result)
+        if not m:
+            m = re.search (r'time=\d+', result)
         if not m :
             if re.search (r'Operation timed out', result) : return SSH_TIMEOUT
             if not re.search (r'PING', result) : return SSH_FAILED


### PR DESCRIPTION
Most linux distros uses either of two flavors of ping -- iputils-ping and inetutils-ping.
The former one does not output the decimal part if RTT > 100ms.
