### PR TITLE
Raise an exception, don't just raise

### DIFF
--- a/deadman
+++ b/deadman
@@ -179,8 +179,7 @@ class Ping :
             self.ipversion = 6
         else :
             self.ipversion = -1
-            print ("invalid IP address \"%s\"" % self.addr)
-            raise
+            raise RuntimeError ("invalid IP address \"%s\"" % self.addr)
 
         self.pingcmdstr = pingcmdstrings (osname, ipv)
 
@@ -214,7 +213,8 @@ class Ping :
             elif self.osname == "Darwin" :
                 sourcecmd += " %s " % ("-S %s" % self.source)
             else :
-                raise
+                raise RuntimeError ("\"source\" not supported on %s" %
+                                    self.osname)
 
         pingcmd = sshcmd + self.pingcmdstr + sourcecmd + " %s" % self.addr
 


### PR DESCRIPTION
The "raise" syntax is only used in an exception handler
to re-raise the original exception.  Otherwise, "raise"
raises an exception that you're raising None:
TypeError: exceptions must be old-style classes or derived from BaseException, not NoneType
which does cause the program to exit but does not provide
any useful information about why.