### PR TITLE
activate "user", "key" option in config

### DIFF
--- a/deadman
+++ b/deadman
@@ -602,7 +602,7 @@ class Deadman :
             relay = {}
             for s in ss :
                 key, value = s.split ("=")
-                if key in ("os", "relay", "via", "community", "netns") :
+                if key in ("os", "relay", "via", "community", "netns", "user") :
                     relay[key] = value
                 elif key == "source" :
                     source = value

--- a/deadman
+++ b/deadman
@@ -602,7 +602,7 @@ class Deadman :
             relay = {}
             for s in ss :
                 key, value = s.split ("=")
-                if key in ("os", "relay", "via", "community", "netns", "user") :
+                if key in ("os", "relay", "via", "community", "netns", "user", "key") :
                     relay[key] = value
                 elif key == "source" :
                     source = value


### PR DESCRIPTION
Fix deadman to use "user", "key" name to login relay host (ssh -l and -i).
Currently it ignores these options.

Sadly username is not always same on local and remote...