### PR TITLE
Be more careful when stripping comments.

### DIFF
--- a/deadman
+++ b/deadman
@@ -588,7 +588,8 @@ class Deadman :
 
             line = re.sub ('\t', ' ', line)
             line = re.sub ('\s+', ' ', line)
-            line = re.sub ('#.*', '', line)
+            line = re.sub ('^#.*', '', line)
+            line = re.sub (';\s*#', '', line)
             line = line.strip (' \r\n')
             line = line.rstrip (' \r\n')
 


### PR DESCRIPTION
This fix only strips strings when the line starts with '#'.  If the line
also contains ";#" sequences, those will be stripped.  Therefore, this
commit allows '#' to appear within the name of a target.