### PR TITLE
Refresh the screen after we update the targets.

### DIFF
--- a/deadman
+++ b/deadman
@@ -615,6 +615,7 @@ class Deadman :
 
     def updatetargets (self, signum, frame) :
         self.addtargets ()
+        self.curs.refresh ()
  
     def gettargetlist (self, configfile) :
 


### PR DESCRIPTION
This prevents phantom lines when you remove targets and HUP.