### PR TITLE
support for env w/o ping6 command

### DIFF
--- a/deadman
+++ b/deadman
@@ -21,6 +21,7 @@ import asyncio
 import concurrent.futures
 from subprocess import DEVNULL, PIPE, getoutput
 import _thread
+from shutil import which
 
 locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
 
@@ -726,7 +727,9 @@ def pingcmd(osname, ipv):
         osname == "Darwin" or
         osname == "FreeBSD"):
         if ipv == 4: return ["ping", "-c", "1"]
-        if ipv == 6: return ["ping6", "-c", "1"]
+        if ipv == 6:
+            if which('ping6'): return ["ping6", "-c", "1"]
+            else: return ["ping", "-c", "1"]
 
     return None
 


### PR DESCRIPTION
Supported to work in the environment without ping6 command like Archlinux.

p.s.
The correspondence to ping6 is divided from the 21st PR.