### PR TITLE
feat: Add support for passing arbitrary ping options (config & command line)

### DIFF
--- a/deadman
+++ b/deadman
@@ -77,7 +77,9 @@ PING_SSH_FAILED   = -3
 
 LOGDIR = ""
 BLINK_ARROW = False
-PING_OPTIONS = []
+PING_OPTIONS = []     # extra ping options from command line, applied to all targets
+PING_OPTIONS_V4 = []  # extra ping options applied to IPv4 targets only
+PING_OPTIONS_V6 = []  # extra ping options applied to IPv6 targets only
 # ToDo: cleanup arguments handling
 
 class PingResult:
@@ -265,8 +267,13 @@ class Ping:
 
         cmd += self.pingcmd
 
-        # extra ping options: command line (global) then per-target config
+        # extra ping options: command line (common, then IP version-specific),
+        # finally per-target config
         cmd += PING_OPTIONS
+        if self.ipversion == 4:
+            cmd += PING_OPTIONS_V4
+        elif self.ipversion == 6:
+            cmd += PING_OPTIONS_V6
         cmd += self.pingopt
 
         # specifying source interface
@@ -975,6 +982,14 @@ if __name__ == '__main__':
                                "all targets, given as a single string. Since "
                                "the value starts with '-', use the '=' form, "
                                "e.g. -o=\"-s 1000 -w 2\"")
+    parser.add_argument("--ping-options-v4", default = "",
+                        dest = "pingopts_v4",
+                        help = "like -o but applied to IPv4 targets only, "
+                               "e.g. --ping-options-v4=\"-s 1000\"")
+    parser.add_argument("--ping-options-v6", default = "",
+                        dest = "pingopts_v6",
+                        help = "like -o but applied to IPv6 targets only, "
+                               "e.g. --ping-options-v6=\"-s 1000\"")
     parser.add_argument("configfile", type = argparse.FileType("r"),
                         help = "config file for deadman")
 
@@ -983,6 +998,8 @@ if __name__ == '__main__':
     BLINK_ARROW = args.blink_arrow
     LOGDIR = args.logdir
     PING_OPTIONS = args.pingopts.split()
+    PING_OPTIONS_V4 = args.pingopts_v4.split()
+    PING_OPTIONS_V6 = args.pingopts_v6.split()
 
     try:
         curses.wrapper(main, args.configfile, args.async_mode)

--- a/deadman
+++ b/deadman
@@ -77,6 +77,7 @@ PING_SSH_FAILED   = -3
 
 LOGDIR = ""
 BLINK_ARROW = False
+PING_OPTIONS = []
 # ToDo: cleanup arguments handling
 
 class PingResult:
@@ -93,7 +94,7 @@ class PingResult:
 class PingTarget:
 
     def __init__(self, name, address, osname, relay = None, source = None,
-                 tcp = None):
+                 tcp = None, pingopt = None):
 
         self.name = name
         self.addr = address
@@ -109,7 +110,7 @@ class PingTarget:
         self.ttl = 0 # last ttl
         self.result = []
         self.ping = Ping(self.addr, osname, relay = relay, source = source,
-                         tcp = tcp)
+                         tcp = tcp, pingopt = pingopt)
 
         return
 
@@ -199,7 +200,7 @@ SEPARATOR = Separator()
 class Ping:
 
     def __init__(self, addr, osname, timeout = 1.0,
-                 relay = None, source = None, tcp = None):
+                 relay = None, source = None, tcp = None, pingopt = None):
 
         self.addr = addr
         self.osname = osname
@@ -207,6 +208,7 @@ class Ping:
         self.source = source
         self.timeout = timeout
         self.tcp = tcp
+        self.pingopt = pingopt or []
 
         self.ipversion = whichipversion(self.addr)
         if not self.ipversion:
@@ -262,6 +264,10 @@ class Ping:
             cmd += [self.relay["relay"]]
 
         cmd += self.pingcmd
+
+        # extra ping options: command line (global) then per-target config
+        cmd += PING_OPTIONS
+        cmd += self.pingopt
 
         # specifying source interface
         if self.source:
@@ -716,14 +722,15 @@ class Deadman:
         newtargets = []
         self.targetlist = self.gettargetlist(self.configfile)
 
-        for name, addr, relay, source, tcp in self.targetlist:
+        for name, addr, relay, source, tcp, pingopt in self.targetlist:
             osname = relay.get('os', OSNAME)
 
             if re.fullmatch(r'-+', name):
                 pt = SEPARATOR
             else:
                 pt = PingTarget(name, addr, osname,
-                                relay = relay, source = source, tcp = tcp)
+                                relay = relay, source = source, tcp = tcp,
+                                pingopt = pingopt)
             idx = -1
             if pt in self.targets:
                 idx = self.targets.index(pt)
@@ -865,6 +872,7 @@ class Deadman:
             addr = ss.pop(0) if ss else None
             source = None
             tcp = None
+            pingopt = []
             relay = {}
             for s in ss:
                 key, value = s.split("=")
@@ -876,8 +884,10 @@ class Deadman:
                     source = value
                 elif key == "tcp":
                     tcp = value
+                elif key == "pingopt":
+                    pingopt = value.split(",")
 
-            targetlist.append([name, addr, relay, source, tcp])
+            targetlist.append([name, addr, relay, source, tcp, pingopt])
 
         configfile.close()
 
@@ -959,6 +969,12 @@ if __name__ == '__main__':
                         help = "blink arrow in async mode")
     parser.add_argument("-l", "--logging", default = None, dest = "logdir",
                         help = "directory for log files")
+    parser.add_argument("-o", "--ping-options", default = "",
+                        dest = "pingopts",
+                        help = "extra options passed to the ping command for "
+                               "all targets, given as a single string. Since "
+                               "the value starts with '-', use the '=' form, "
+                               "e.g. -o=\"-s 1000 -w 2\"")
     parser.add_argument("configfile", type = argparse.FileType("r"),
                         help = "config file for deadman")
 
@@ -966,6 +982,7 @@ if __name__ == '__main__':
     RTT_SCALE = args.scale
     BLINK_ARROW = args.blink_arrow
     LOGDIR = args.logdir
+    PING_OPTIONS = args.pingopts.split()
 
     try:
         curses.wrapper(main, args.configfile, args.async_mode)

--- a/deadman.conf
+++ b/deadman.conf
@@ -60,3 +60,16 @@ kame6		2001:2f0:0:8800::1:1
 #	Name	Address tcp=dstport:80
 #
 #wide-tcp80	203.178.136.59 tcp=dstport:80
+
+#
+#	pass arbitrary options to the ping command (per target).
+#		Since config tokens are split by whitespace, options are
+#		given as comma-separated tokens.
+#		The command line option "-o"/"--ping-options" passes options
+#		to all targets; per-target "pingopt" is appended after them.
+#		Use the '=' form on the command line, e.g. -o="-s 1000 -w 2".
+#
+#	Syntax
+#	Name	Address pingopt=-s,1000,-w,2
+#
+#googleDNS-bigpkt	8.8.8.8 pingopt=-s,1000,-w,2

--- a/deadman.conf
+++ b/deadman.conf
@@ -66,7 +66,9 @@ kame6		2001:2f0:0:8800::1:1
 #		Since config tokens are split by whitespace, options are
 #		given as comma-separated tokens.
 #		The command line option "-o"/"--ping-options" passes options
-#		to all targets; per-target "pingopt" is appended after them.
+#		to all targets; "--ping-options-v4" / "--ping-options-v6" pass
+#		options to IPv4 / IPv6 targets only. Per-target "pingopt" is
+#		appended after them.
 #		Use the '=' form on the command line, e.g. -o="-s 1000 -w 2".
 #
 #	Syntax


### PR DESCRIPTION
  Adds a mechanism to pass arbitrary `ping` options through two paths:

  - **Config file (per-target)**: specify per target via `pingopt=`
  - **Command line (all targets / per IP version)**: `-o` / `--ping-options-v4` / `--ping-options-v6`

  This makes it possible to flexibly pass `ping` options such as packet size (`-s`)
  or any other options depending on the target or IP version.

  ## Usage

  ### Config file (per-target)

  Since the config splits tokens by whitespace, options are given as
  **comma-separated** tokens:

  ```
  googleDNS-bigpkt   8.8.8.8   pingopt=-s,1000,-w,2
  ```

  ### Command line

  ```sh
  # Common to all targets
  ./deadman -o="-s 1472" deadman.conf

  # Separate options for IPv4 / IPv6
  ./deadman --ping-options-v4="-s 1472" --ping-options-v6="-s 1452" deadman.conf
  ```

  Because the value starts with `-`, use the `=` form on the command line.

  ### Order of application

  Options are concatenated onto the `ping` command in this order:

  ```
  common (-o)  →  per IP version (--ping-options-v4 / -v6)  →  per-target (config pingopt=)
  ```

  ## Changes

  - Add a `pingopt` argument to `Ping` / `PingTarget`, and inject the options when
    building the `ping` command in `Ping.async_send()` (dispatching v4/v6 via `Ping.ipversion`)
  - Add a `pingopt=` key to the config parser (`gettargetlist`), splitting the
    comma-separated value into tokens
  - Add the `-o`/`--ping-options`, `--ping-options-v4`, and `--ping-options-v6`
    command-line arguments
  - Document the usage with examples in `deadman.conf`

  ## Notes

  - These options apply to regular ICMP ping (including via SSH / netns / vrf).
    The `tcp` / `snmp` / `routeros_api` paths do not use the `ping` command, so
    they are out of scope.